### PR TITLE
Stop respecting `require.extensions`

### DIFF
--- a/fixture/nonstd.xjs
+++ b/fixture/nonstd.xjs
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = 'nonstd';

--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ delete require.cache[__filename];
 const parentFile = module.parent.filename;
 const parentDirectory = path.dirname(parentFile);
 
-// The default extensions used by NodeJS require().
-// Previously we relied on the now deprecated `require.extensions`.
+// The default file extensions used by `require()`.
 const extensions = new Set(['.js', '.json', '.node']);
 
 module.exports = (directory, options) => {

--- a/index.js
+++ b/index.js
@@ -7,11 +7,16 @@ delete require.cache[__filename];
 const parentFile = module.parent.filename;
 const parentDirectory = path.dirname(parentFile);
 
+// The default extensions used by NodeJS require().
+// Previously we relied on the now deprecated `require.extensions`.
+const extensions = new Set(['.js', '.json', '.node']);
+
 module.exports = (directory, options) => {
 	directory = path.resolve(parentDirectory, directory || '');
 
 	options = {
 		camelize: true,
+		extensions,
 		...options
 	};
 
@@ -25,11 +30,7 @@ module.exports = (directory, options) => {
 	const done = new Set();
 	const returnValue = {};
 
-	// The default extensions used by NodeJS require().
-	// Previously we relied on the now deprecated `require.extensions`.
-	const extensions = new Set(['.js', '.json', '.node']);
-
-	for (const extension of extensions) {
+	for (const extension of options.extensions) {
 		for (const file of files) {
 			const filenameStem = path.basename(file).replace(/\.\w+$/, '');
 			const fullPath = path.join(directory, file);

--- a/index.js
+++ b/index.js
@@ -25,9 +25,11 @@ module.exports = (directory, options) => {
 	const done = new Set();
 	const returnValue = {};
 
-	// Adhere to the Node.js require algorithm by trying each extension in order
-	// eslint-disable-next-line node/no-deprecated-api
-	for (const extension of Object.keys(require.extensions)) {
+	// The default extensions used by NodeJS require().
+	// Previously we relied on the now deprecated `require.extensions`.
+	const extensions = new Set(['.js', '.json', '.node']);
+
+	for (const extension of extensions) {
 		for (const file of files) {
 			const filenameStem = path.basename(file).replace(/\.\w+$/, '');
 			const fullPath = path.join(directory, file);

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ console.log(modules);
 Type: `string`<br>
 Default: `__dirname`
 
-Directory to import modules from. Unless you've modified [`require.extensions`](https://nodejs.org/api/globals.html#globals_require_extensions), that means any `.js`, `.json`, `.node` files, in that order. Does not recurse. Ignores the caller file and files starting with `.` or `_`.
+Directory to import modules from. Unless you've defined the extensions (via options), that means any `.js`, `.json`, `.node` files, in that order. Does not recurse. Ignores the caller file and files starting with `.` or `_`.
 
 #### options
 
@@ -53,6 +53,12 @@ Default: `true`
 
 Convert dash-style names (`foo-bar`) to camel-case (`fooBar`).
 
+##### extensions
+
+Type: `iterable`<br>
+Default: `new Set(['.js', '.json', '.node'])`
+
+Defaults to the current `require.extensions` (deprecated) in NodeJS for extensions. Order is important for correct lookup priority.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -55,10 +55,11 @@ Convert dash-style names (`foo-bar`) to camel-case (`fooBar`).
 
 ##### extensions
 
-Type: `iterable`<br>
-Default: `new Set(['.js', '.json', '.node'])`
+Type: `string[]`<br>
+Default: `['.js', '.json', '.node']`
 
-Defaults to the current `require.extensions` (deprecated) in NodeJS for extensions. Order is important for correct lookup priority.
+File extensions to look for. Order matters.
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ console.log(modules);
 Type: `string`<br>
 Default: `__dirname`
 
-Directory to import modules from. Unless you've set the `extension` option, that means any `.js`, `.json`, `.node` files, in that order. Does not recurse. Ignores the caller file and files starting with `.` or `_`.
+Directory to import modules from. Unless you've set the `extensions` option, that means any `.js`, `.json`, `.node` files, in that order. Does not recurse. Ignores the caller file and files starting with `.` or `_`.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ console.log(modules);
 Type: `string`<br>
 Default: `__dirname`
 
-Directory to import modules from. Unless you've defined the extensions (via options), that means any `.js`, `.json`, `.node` files, in that order. Does not recurse. Ignores the caller file and files starting with `.` or `_`.
+Directory to import modules from. Unless you've set the `extension` option, that means any `.js`, `.json`, `.node` files, in that order. Does not recurse. Ignores the caller file and files starting with `.` or `_`.
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ test('main', t => {
 		barBar: 'bar'
 	});
 	t.deepEqual(Object.keys(importModules('fixture', {camelize: false})), ['bar-bar', 'foo-foo']);
+	t.deepEqual(Object.keys(importModules('fixture', {camelize: false, extensions: ['.xjs']})), ['nonstd']);
 	t.deepEqual(Object.keys(importModules()), ['index', 'package']);
 	t.deepEqual(importModules('fixture/empty'), {});
 	t.deepEqual(importModules('non-existent'), {});


### PR DESCRIPTION
This uses a manual list of extensions. It might not be something NodeJS will support for any longer so it's probably a good idea to replace it.

It supports overriding that list via `options`. This was also added/corrected in the readme.

Tests are green.

Fixes: https://github.com/sindresorhus/import-modules/issues/2