### PR TITLE
Don't silently fail when the directory does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const fileExtensions = new Set(['.js', '.json', '.node']);
 
 module.exports = (directory, options) => {
 	directory = path.resolve(parentDirectory, directory || '');
-
 	options = {
 		camelize: true,
 		fileExtensions,
@@ -22,8 +21,8 @@ module.exports = (directory, options) => {
 	let files;
 	try {
 		files = fs.readdirSync(directory);
-	} catch (err) {
-		throw err;
+	} catch (error) {
+		throw error;
 	}
 
 	const done = new Set();

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ module.exports = (directory, options) => {
 	let files;
 	try {
 		files = fs.readdirSync(directory);
-	} catch (_) {
-		return {};
+	} catch (err) {
+		throw err;
 	}
 
 	const done = new Set();

--- a/index.js
+++ b/index.js
@@ -12,18 +12,14 @@ const fileExtensions = new Set(['.js', '.json', '.node']);
 
 module.exports = (directory, options) => {
 	directory = path.resolve(parentDirectory, directory || '');
+
 	options = {
 		camelize: true,
 		fileExtensions,
 		...options
 	};
 
-	let files;
-	try {
-		files = fs.readdirSync(directory);
-	} catch (error) {
-		throw error;
-	}
+	const files = fs.readdirSync(directory);
 
 	const done = new Set();
 	const returnValue = {};

--- a/test.js
+++ b/test.js
@@ -14,8 +14,7 @@ test('main', t => {
 });
 
 test('non-existent directory', t => {
-	const error = t.throws(() => {
+	t.throws(() => {
 		importModules('non-existent');
-	});
-	t.true(error.message.includes('no such file or directory'));
+	}, {message: /\bno such file or directory\b/});
 });

--- a/test.js
+++ b/test.js
@@ -11,5 +11,11 @@ test('main', t => {
 	t.deepEqual(Object.keys(importModules('fixture', {camelize: false, fileExtensions: ['.xjs']})), ['non-standard']);
 	t.deepEqual(Object.keys(importModules()), ['index', 'package']);
 	t.deepEqual(importModules('fixture/empty'), {});
-	t.deepEqual(importModules('non-existent'), {});
+});
+
+test('non-existent directory', t => {
+	const error = t.throws(() => {
+		importModules('non-existent');
+	});
+	t.true(error.message.includes('no such file or directory'));
 });


### PR DESCRIPTION
Ran into an issue where I was trying to publish a package that used `import-modules`, and ran into a fun bug where the directory being read would work fine from inside the module, but not when imported from  a second package. It would've been helpful to get an error describing what happened instead of failing silently - it would've saved me several `npm publish` commands :) 

Anyways I added error throwing and a test to prove that it works. 