### PR TITLE
Add TypeScript definition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
           - 14
           - 12
           - 10
-          - 8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,14 +18,10 @@ export interface Options {
 	readonly fileExtensions?: string[];
 }
 
-/* eslint-disable @typescript-eslint/ban-types */
-type Module = Function[];
-
 /**
-Import all modules in a directory
+Import all modules in a directory.
 
-@param directory
-@param options
+@param directory - Directory to import modules from. Unless you've set the `fileExtensions` option, that means any `.js`, `.json`, `.node` files, in that order. Does not recurse. Ignores the caller file and files starting with `.` or `_`.
 
 @example
 
@@ -39,7 +35,9 @@ console.log(modules);
 //=> {fooBar: [Function], bazFaz: [Function]}
 ```
 */
-export default function importModules(
+declare function importModules(
 	directory?: string,
 	options?: Options,
-): Partial<Record<string, Module>>;
+): unknown;
+
+export = importModules;

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,6 @@ console.log(modules);
 declare function importModules(
 	directory?: string,
 	options?: Options,
-): unknown;
+): Partial<Record<string, unknown>>;
 
 export = importModules;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,9 +35,7 @@ console.log(modules);
 //=> {fooBar: [Function], bazFaz: [Function]}
 ```
 */
-declare function importModules(
+export default function importModules(
 	directory?: string,
 	options?: Options,
 ): Record<string, unknown>;
-
-export = importModules;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,45 @@
+export interface Options {
+	/**
+	Convert *dash-style* names (`foo-bar`) and *snake-style* names (`foo_bar`) to *camel-case* (`fooBar`).
+
+	@default true
+	*/
+	readonly camelize?: boolean;
+
+	/**
+	File extensions to look for.
+
+	Unless you've set the `fileExtensions` option, that means any `.js`, `.json`, `.node` files, in that order.
+
+	Does not recurse. Ignores the caller file and files starting with `.` or `_`.
+
+	@default ['.js', '.json', '.node']
+	*/
+	readonly fileExtensions?: string[];
+}
+
+/* eslint-disable @typescript-eslint/ban-types */
+type Module = Function[];
+
+/**
+Import all modules in a directory
+
+@param directory
+@param options
+
+@example
+
+```js
+// Assuming `foo-bar.js`, `baz-faz.js` files under the `directory` folder.
+const importModules = require('import-modules');
+
+const modules = importModules('directory');
+
+console.log(modules);
+//=> {fooBar: [Function], bazFaz: [Function]}
+```
+*/
+export default function importModules(
+	directory?: string,
+	options?: Options,
+): Partial<Record<string, Module>>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,6 @@ console.log(modules);
 declare function importModules(
 	directory?: string,
 	options?: Options,
-): Partial<Record<string, unknown>>;
+): Record<string, unknown>;
 
 export = importModules;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,11 +1,11 @@
 import process from 'node:process';
 import {expectType} from 'tsd';
-import importModules, {Module} from './index.js';
+import importModules from './index.js';
 
 const currentDirectory: string = process.cwd();
 
-expectType<Partial<Record<string, Module>>>(importModules());
-expectType<Partial<Record<string, Module>>>(importModules(currentDirectory));
-expectType<Partial<Record<string, Module>>>(importModules(currentDirectory, {fileExtensions: ['.js']}));
-expectType<Partial<Record<string, Module>>>(importModules(currentDirectory, {camelize: false, fileExtensions: ['.js']}));
-expectType<Partial<Record<string, Module>>>(importModules(currentDirectory, {fileExtensions: []}));
+expectType<Record<string, unknown>>(importModules());
+expectType<Record<string, unknown>>(importModules(currentDirectory));
+expectType<Record<string, unknown>>(importModules(currentDirectory, {fileExtensions: ['.js']}));
+expectType<Record<string, unknown>>(importModules(currentDirectory, {camelize: false, fileExtensions: ['.js']}));
+expectType<Record<string, unknown>>(importModules(currentDirectory, {fileExtensions: []}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,11 @@
+import process from 'node:process';
+import {expectType} from 'tsd';
+import importModules, {Module} from './index.js';
+
+const currentDirectory: string = process.cwd();
+
+expectType<Partial<Record<string, Module>>>(importModules());
+expectType<Partial<Record<string, Module>>>(importModules(currentDirectory));
+expectType<Partial<Record<string, Module>>>(importModules(currentDirectory, {fileExtensions: ['.js']}));
+expectType<Partial<Record<string, Module>>>(importModules(currentDirectory, {camelize: false, fileExtensions: ['.js']}));
+expectType<Partial<Record<string, Module>>>(importModules(currentDirectory, {fileExtensions: []}));

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"import",
@@ -34,6 +35,7 @@
 	],
 	"devDependencies": {
 		"ava": "^2.4.0",
+		"tsd": "^0.19.1",
 		"xo": "^0.25.3"
 	},
 	"xo": {


### PR DESCRIPTION
Fixes #12.

* Most of the descriptions (including example) are copy-pasted from README.
* I made the function's return type to `Partial<Record<string, Module>>>` because I think the record might be empty.
* If I missed something, I'd appreciate your letting me know.