### PR TITLE
Generic return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ console.log(modules);
 //=> {fooBar: [Function], bazFaz: [Function]}
 ```
 */
-export default function importModules(
+export default function importModules<T=unknown>(
 	directory?: string,
 	options?: Options,
-): Record<string, unknown>;
+): Record<string, T>;


### PR DESCRIPTION
A generic return type needed for organized folders where each file exports same interface. For example: Http Routers folder. The commit does the job please approve it. 